### PR TITLE
Fix read access for 16bit timer counter registers.

### DIFF
--- a/framework/cores/AVR8Bit/WHardwareTimer.cpp
+++ b/framework/cores/AVR8Bit/WHardwareTimer.cpp
@@ -781,9 +781,9 @@ uint16_t HardwareTimer::getCounter(void)
   uint16_t value = 0;
   uint8_t oldSREG = SREG;
   cli();
+  value += *_tcntnl;
   if (_tcntnh != NULL)
     value = *_tcntnh << 8;
-  value += *_tcntnl;
   SREG = oldSREG;
 
   return value;


### PR DESCRIPTION
To get meaningful reading, we must read the low byte
first, so the MCU saves the correct high byte value in
the counter's temporary register (see eg. section 14.2
of the 32u4 datasheet).
