### PR TITLE
Allow pin numbers beside channel number for analogRead().

### DIFF
--- a/framework/cores/AVR8Bit/WAnalog.c
+++ b/framework/cores/AVR8Bit/WAnalog.c
@@ -61,6 +61,10 @@ int16_t analogRead(uint8_t pin)
     adcFirstTime = false;
   }
 
+  // allow for channel or pin numbers
+  if (pin >= FIRST_ANALOG_PIN)
+    pin -= FIRST_ANALOG_PIN;
+
   // The only megaAVR 8 bit controllers that have 16 single-ended a/d channels
   // are the ATmega640/1280/2560
 #if defined(MUX5)

--- a/framework/hardware/Arduino/DuemilanoveUno/BoardDefs.h
+++ b/framework/hardware/Arduino/DuemilanoveUno/BoardDefs.h
@@ -50,12 +50,12 @@ const static uint8_t SCL  = 19;
 const static uint8_t SDA  = 18;
 
 // Analog pins
-const static uint8_t A0 = 0;
-const static uint8_t A1 = 1;
-const static uint8_t A2 = 2;
-const static uint8_t A3 = 3;
-const static uint8_t A4 = 4;
-const static uint8_t A5 = 5;
+const static uint8_t A0 = 14;
+const static uint8_t A1 = 15;
+const static uint8_t A2 = 16;
+const static uint8_t A3 = 17;
+const static uint8_t A4 = 18;
+const static uint8_t A5 = 19;
 
 // External Interrupts
 const static uint8_t EI0 = 2;

--- a/framework/hardware/Arduino/Mega12802560/BoardDefs.h
+++ b/framework/hardware/Arduino/Mega12802560/BoardDefs.h
@@ -50,22 +50,22 @@ const static uint8_t SCL  = 21;
 const static uint8_t SDA  = 20;
 
 // Analog pins
-const static uint8_t A0 = 0;
-const static uint8_t A1 = 1;
-const static uint8_t A2 = 2;
-const static uint8_t A3 = 3;
-const static uint8_t A4 = 4;
-const static uint8_t A5 = 5;
-const static uint8_t A6 = 6;
-const static uint8_t A7 = 7;
-const static uint8_t A8 = 8;
-const static uint8_t A9 = 9;
-const static uint8_t A10 = 10;
-const static uint8_t A11 = 11;
-const static uint8_t A12 = 12;
-const static uint8_t A13 = 13;
-const static uint8_t A14 = 14;
-const static uint8_t A15 = 15;
+const static uint8_t A0 = 54;
+const static uint8_t A1 = 55;
+const static uint8_t A2 = 56;
+const static uint8_t A3 = 57;
+const static uint8_t A4 = 58;
+const static uint8_t A5 = 59;
+const static uint8_t A6 = 60;
+const static uint8_t A7 = 61;
+const static uint8_t A8 = 62;
+const static uint8_t A9 = 63;
+const static uint8_t A10 = 64;
+const static uint8_t A11 = 65;
+const static uint8_t A12 = 66;
+const static uint8_t A13 = 67;
+const static uint8_t A14 = 68;
+const static uint8_t A15 = 68;
 
 // External Interrupts
 const static uint8_t EI0 = 21;

--- a/framework/hardware/Atmel/ATmegaXX4P-PA/BoardDefs.h
+++ b/framework/hardware/Atmel/ATmegaXX4P-PA/BoardDefs.h
@@ -50,14 +50,14 @@ const static uint8_t SCL  = 8;
 const static uint8_t SDA  = 9;
 
 // Analog pins
-const static uint8_t A0 = 0;
-const static uint8_t A1 = 1;
-const static uint8_t A2 = 2;
-const static uint8_t A3 = 3;
-const static uint8_t A4 = 4;
-const static uint8_t A5 = 5;
-const static uint8_t A6 = 6;
-const static uint8_t A7 = 7;
+const static uint8_t A0 = 24;
+const static uint8_t A1 = 25;
+const static uint8_t A2 = 26;
+const static uint8_t A3 = 27;
+const static uint8_t A4 = 28;
+const static uint8_t A5 = 29;
+const static uint8_t A6 = 30;
+const static uint8_t A7 = 31;
 
 // External Interrupts
 const static uint8_t EI0 = 2;

--- a/framework/hardware/Atmel/ATmegaXX8P-PA/BoardDefs.h
+++ b/framework/hardware/Atmel/ATmegaXX8P-PA/BoardDefs.h
@@ -50,12 +50,12 @@ const static uint8_t SCL  = 19;
 const static uint8_t SDA  = 18;
 
 // Analog pins
-const static uint8_t A0 = 0;
-const static uint8_t A1 = 1;
-const static uint8_t A2 = 2;
-const static uint8_t A3 = 3;
-const static uint8_t A4 = 4;
-const static uint8_t A5 = 5;
+const static uint8_t A0 = 14;
+const static uint8_t A1 = 15;
+const static uint8_t A2 = 16;
+const static uint8_t A3 = 17;
+const static uint8_t A4 = 18;
+const static uint8_t A5 = 19;
 
 // External Interrupts
 const static uint8_t EI0 = 2;

--- a/framework/hardware/BDMicro/MavricIIB/BoardDefs.h
+++ b/framework/hardware/BDMicro/MavricIIB/BoardDefs.h
@@ -58,14 +58,14 @@ const static uint8_t SCL  = 8;
 const static uint8_t SDA  = 9;
 
 // Analog pins
-const static uint8_t A0 = 0;
-const static uint8_t A1 = 1;
-const static uint8_t A2 = 2;
-const static uint8_t A3 = 3;
-const static uint8_t A4 = 4;
-const static uint8_t A5 = 5;
-const static uint8_t A6 = 6;
-const static uint8_t A7 = 7;
+const static uint8_t A0 = 32;
+const static uint8_t A1 = 33;
+const static uint8_t A2 = 34;
+const static uint8_t A3 = 35;
+const static uint8_t A4 = 36;
+const static uint8_t A5 = 37;
+const static uint8_t A6 = 38;
+const static uint8_t A7 = 39;
 
 // External Interrupts
 const static uint8_t EI0 = 8;

--- a/framework/hardware/RogueRobotics/LEDHead/BoardDefs.h
+++ b/framework/hardware/RogueRobotics/LEDHead/BoardDefs.h
@@ -53,14 +53,14 @@ const static uint8_t SCL  = 24;
 const static uint8_t SDA  = 25;
 
 // Analog pins
-const static uint8_t A0 = 0;
-const static uint8_t A1 = 1;
-const static uint8_t A2 = 2;
-const static uint8_t A3 = 3;
-const static uint8_t A4 = 4;
-const static uint8_t A5 = 5;
-const static uint8_t A6 = 6;
-const static uint8_t A7 = 7;
+const static uint8_t A0 = 24;
+const static uint8_t A1 = 25;
+const static uint8_t A2 = 26;
+const static uint8_t A3 = 27;
+const static uint8_t A4 = 28;
+const static uint8_t A5 = 29;
+const static uint8_t A6 = 30;
+const static uint8_t A7 = 31;
 
 // External Interrupts
 const static uint8_t EI0 = 2;

--- a/framework/hardware/RogueRobotics/uMMC-200/BoardDefs.h
+++ b/framework/hardware/RogueRobotics/uMMC-200/BoardDefs.h
@@ -51,14 +51,14 @@ const static uint8_t SCL  = 8;
 const static uint8_t SDA  = 9;
 
 // Analog pins
-const static uint8_t A0 = 0;
-const static uint8_t A1 = 1;
-const static uint8_t A2 = 2;
-const static uint8_t A3 = 3;
-const static uint8_t A4 = 4;
-const static uint8_t A5 = 5;
-const static uint8_t A6 = 6;
-const static uint8_t A7 = 7;
+const static uint8_t A0 = 24;
+const static uint8_t A1 = 25;
+const static uint8_t A2 = 26;
+const static uint8_t A3 = 27;
+const static uint8_t A4 = 28;
+const static uint8_t A5 = 29;
+const static uint8_t A6 = 30;
+const static uint8_t A7 = 31;
 
 // External Interrupts
 const static uint8_t EI0 = 2;

--- a/framework/hardware/Wiring/Wiring1.1/BoardDefs.h
+++ b/framework/hardware/Wiring/Wiring1.1/BoardDefs.h
@@ -53,14 +53,14 @@ const static uint8_t SCL  = 0;
 const static uint8_t SDA  = 1;
 
 // Analog pins
-const static uint8_t A0 = 0;
-const static uint8_t A1 = 1;
-const static uint8_t A2 = 2;
-const static uint8_t A3 = 3;
-const static uint8_t A4 = 4;
-const static uint8_t A5 = 5;
-const static uint8_t A6 = 6;
-const static uint8_t A7 = 7;
+const static uint8_t A0 = 40;
+const static uint8_t A1 = 41;
+const static uint8_t A2 = 42;
+const static uint8_t A3 = 43;
+const static uint8_t A4 = 44;
+const static uint8_t A5 = 45;
+const static uint8_t A6 = 46;
+const static uint8_t A7 = 47;
 
 // External Interrupts
 const static uint8_t EI0 = 2;

--- a/framework/hardware/Wiring/Wiring1/BoardDefs.h
+++ b/framework/hardware/Wiring/Wiring1/BoardDefs.h
@@ -53,14 +53,14 @@ const static uint8_t SCL  = 0;
 const static uint8_t SDA  = 1;
 
 // Analog pins
-const static uint8_t A0 = 0;
-const static uint8_t A1 = 1;
-const static uint8_t A2 = 2;
-const static uint8_t A3 = 3;
-const static uint8_t A4 = 4;
-const static uint8_t A5 = 5;
-const static uint8_t A6 = 6;
-const static uint8_t A7 = 7;
+const static uint8_t A0 = 40;
+const static uint8_t A1 = 41;
+const static uint8_t A2 = 42;
+const static uint8_t A3 = 43;
+const static uint8_t A4 = 44;
+const static uint8_t A5 = 45;
+const static uint8_t A6 = 46;
+const static uint8_t A7 = 47;
 
 // External Interrupts
 const static uint8_t EI0 = 2;

--- a/framework/hardware/Wiring/WiringS/BoardDefs.h
+++ b/framework/hardware/Wiring/WiringS/BoardDefs.h
@@ -49,14 +49,14 @@ const static uint8_t SCL  = 8;
 const static uint8_t SDA  = 9;
 
 // Analog pins
-const static uint8_t A0 = 0;
-const static uint8_t A1 = 1;
-const static uint8_t A2 = 2;
-const static uint8_t A3 = 3;
-const static uint8_t A4 = 4;
-const static uint8_t A5 = 5;
-const static uint8_t A6 = 6;
-const static uint8_t A7 = 7;
+const static uint8_t A0 = 24;
+const static uint8_t A1 = 25;
+const static uint8_t A2 = 26;
+const static uint8_t A3 = 27;
+const static uint8_t A4 = 28;
+const static uint8_t A5 = 29;
+const static uint8_t A6 = 30;
+const static uint8_t A7 = 31;
 
 // External Interrupts
 const static uint8_t EI0 = 2;

--- a/framework/hardware/Wiring/WiringSPlayShield/BoardDefs.h
+++ b/framework/hardware/Wiring/WiringSPlayShield/BoardDefs.h
@@ -49,14 +49,14 @@ const static uint8_t SCL  = 26;
 const static uint8_t SDA  = 27;
 
 // Analog pins
-const static uint8_t A0 = 0;
-const static uint8_t A1 = 1;
-const static uint8_t A2 = 2;
-const static uint8_t A3 = 3;
-const static uint8_t A4 = 4;
-const static uint8_t A5 = 5;
-const static uint8_t A6 = 6;
-const static uint8_t A7 = 7;
+const static uint8_t A0 = 14;
+const static uint8_t A1 = 15;
+const static uint8_t A2 = 16;
+const static uint8_t A3 = 17;
+const static uint8_t A4 = 18;
+const static uint8_t A5 = 19;
+const static uint8_t A6 = 20;
+const static uint8_t A7 = 21;
 
 // External Interrupts
 const static uint8_t EI0 = 2;


### PR DESCRIPTION
I propose to change the values of the A0, A1, ... constants to be the pin number, not the ADC channel number.
This way you can do things like
    digitalRead(A0);
where you would otherwise have to find out the pin number of the pin labeled "A0" on your board.

The patch should be completely backwards-compatible.
