### PR TITLE
Replace MULTIPRESS event with getPressCount method to be backwards compatible

### DIFF
--- a/framework/libraries/Keypad/Keypad.cpp
+++ b/framework/libraries/Keypad/Keypad.cpp
@@ -53,6 +53,7 @@ Keypad::Keypad(char *userKeymap, byte *row, byte *col, byte rows, byte cols)
   currentKey = NO_KEY;
   lastKey = NO_KEY;
   state = IDLE;
+  pressCount = 0;
 
   initializePins();
 }
@@ -115,11 +116,13 @@ EVALUATE_KEY:
   {
     if (key == lastKey && ((millis() - lastPress) <= multiPressTime))
     {
+        pressCount++; // increase press count to return the correct key (if multiple keys are available)
         currentKey = key;
-        transitionTo(MULTIPRESS);
+        transitionTo(PRESSED);
     }
     else if (key != currentKey)
     {
+        pressCount = 1; // key was pressed the first time
         currentKey = key;
         transitionTo(PRESSED);
     }
@@ -145,6 +148,18 @@ EVALUATE_KEY:
 KeypadState Keypad::getState()
 {
   return state;
+}
+
+/*
+|| @description
+|| | Get the multi press count of the current key
+|| #
+||
+|| @return The current multi press count of the current pressed key
+*/
+unsigned int Keypad::getPressCount()
+{
+  return pressCount;
 }
 
 /*

--- a/framework/libraries/Keypad/Keypad.h
+++ b/framework/libraries/Keypad/Keypad.h
@@ -34,7 +34,6 @@ typedef enum
 {
   IDLE = 0,
   PRESSED,
-  MULTIPRESS,
   RELEASED,
   HOLD
 } KeypadState;
@@ -60,6 +59,7 @@ class Keypad
 
     char getKey();
     KeypadState getState();
+    unsigned int getPressCount();
 
     void setMultiPressTime(unsigned int multipress);
     void setDebounceTime(unsigned int debounce);
@@ -82,6 +82,7 @@ class Keypad
     KeypadState state;
     char currentKey;
     char lastKey;
+    unsigned int pressCount;
     unsigned long lastUpdate;
     unsigned long lastPress;
     unsigned int multiPressTime;

--- a/framework/libraries/Keypad/examples/MultiPressEventKeypad/MultiPressEventKeypad.pde
+++ b/framework/libraries/Keypad/examples/MultiPressEventKeypad/MultiPressEventKeypad.pde
@@ -1,11 +1,11 @@
 /**
  * MultiPressEventKeypad
- * by Simon Kirchner
+ * by https://github.com/cyborgsimon
  * 
- * This example demonstates the event API for keypads and the new multi press event
+ * This example demonstates the event API for keypads and the new 
  * Multi press will not work if delay is used since it needs the keypad.getKey to 
  * get read before the multiPressTime has passed.
- * Look at this example if you need multi   press with blinking leds
+ * Look at this example if you need multi press with blinking leds
  * http://arduino.cc/en/Tutorial/BlinkWithoutDelay
  */
  
@@ -24,35 +24,29 @@ byte colPins[COLS] = {6,7,8,9}; //connect to the column pinouts of the keypad
 
 Keypad keypad = Keypad( makeKeymap(keys), rowPins, colPins, ROWS, COLS );
 
-boolean blink = false;
-
 void setup(){
   Serial.begin(9600);
   keypad.addEventListener(keypadEvent); //add an event listener for this keypad
 }
   
 void loop(){
-  char key = keypad.getKey();
-  
-  if (key != NO_KEY) {
-    Serial.println(key);
-  }
+  keypad.getKey();
 }
 
 //take care of some special events
 void keypadEvent(KeypadEvent key){
+  Serial.print(key);
   switch (keypad.getState()){
     case PRESSED:
-      Serial.println("PRESSED");
-    break;
-    case MULTIPRESS:
-      Serial.println("MULTIPRESS");
+      Serial.println(" PRESSED");
+      Serial.print("press count: ");
+      Serial.println(keypad.getPressCount());
     break;
     case RELEASED:
-      Serial.println("RELEASED");
+      Serial.println(" RELEASED");
     break;
     case HOLD:
-      Serial.println("HOLD");
+      Serial.println(" HOLD");
     break;
   }
 }

--- a/framework/libraries/Keypad/keywords.txt
+++ b/framework/libraries/Keypad/keywords.txt
@@ -16,6 +16,8 @@ KeypadEvent                    KEYWORD1
 begin                          KEYWORD2
 getKey                         KEYWORD2
 getState                       KEYWORD2
+getPressCount                  KEYWORD2
+setMultiPressTime              KEYWORD2
 setHoldTime                    KEYWORD2
 setEventListener               KEYWORD2
 


### PR DESCRIPTION
MULTIPRESS may break projects using the PRESSED event since MULTIPRESS
is triggered instead of PRESSED
use getPressCount() to find out how often the key (multi press) was
pressed, when the PRESSED event is triggered
updated the example
updated keywords.txt
