### PR TITLE
Replace multiClickHandler trigger with the getClickCount method to be backwards compatible

### DIFF
--- a/framework/libraries/Button/Button.h
+++ b/framework/libraries/Button/Button.h
@@ -45,22 +45,23 @@ class Button
 
     void setDebounceTime(unsigned int debounce);
     void setHoldThreshold(unsigned int holdTime);
+    void setMultiClickThreshold(unsigned int multiClickTime);
     bool held(unsigned int time = 0);
     bool heldFor(unsigned int time);
-
-    void setMultiClickThreshold(unsigned int multiClickTime);
 
     void pressHandler(buttonEventHandler handler);
     void releaseHandler(buttonEventHandler handler);
     void clickHandler(buttonEventHandler handler);
-    void multiClickHandler(buttonEventHandler handler, unsigned int multiClickTime = 0);
     void holdHandler(buttonEventHandler handler, unsigned int holdTime = 0);
 
     unsigned int holdTime() const;
+    // returns the total count of presses
     inline unsigned int presses() const
     {
       return numberOfPresses;
     }
+    // returns the count of "multi" clicks
+    unsigned int getClickCount();
 
     bool operator==(Button &rhs);
 
@@ -76,9 +77,9 @@ class Button
     buttonEventHandler cb_onPress;
     buttonEventHandler cb_onRelease;
     buttonEventHandler cb_onClick;
-    buttonEventHandler cb_onMultiClick;
     buttonEventHandler cb_onHold;
-    unsigned int numberOfPresses;
+    unsigned int numberOfPresses; // holds the total count of presses
+    unsigned int clickCount; // holds the count of clicks
     bool triggeredHoldEvent;
 };
 

--- a/framework/libraries/Button/examples/MultiClickEventButton/MultiClickEventButton.pde
+++ b/framework/libraries/Button/examples/MultiClickEventButton/MultiClickEventButton.pde
@@ -5,10 +5,10 @@
  * Use a button connected to digital pin 12.
  * Digital pin 12 is used as input and connected to a button
  * 
- * This example demonstates the event API for buttons and the new multiclick event
+ * This example demonstates the event API for buttons and the new getClickCount method.
  * Multi click will not work if delay is used since it needs the button.iPressed to 
  * get read before the multiClickTreshold has passed.
- * Look at this example if you need multiclick with blinking leds
+ * Look at this example if you need multi click with blinking leds
  * http://arduino.cc/en/Tutorial/BlinkWithoutDelay
  */
  
@@ -35,12 +35,8 @@ void handleButtonReleaseEvents(Button &btn)
 
 void handleButtonClickEvents(Button &btn)
 {
-  Serial.println("click");
-}
-
-void handleButtonMultiClickEvents(Button &btn)
-{
-  Serial.println("multiclick");
+  Serial.print("click count ");
+  Serial.println(button.getClickCount());
 }
 
 void handleButtonHoldEvents(Button &btn)

--- a/framework/libraries/Button/keywords.txt
+++ b/framework/libraries/Button/keywords.txt
@@ -16,10 +16,12 @@ isPressed                      KEYWORD2
 wasPressed                     KEYWORD2
 stateChanged                   KEYWORD2
 uniquePress                    KEYWORD2
+getClickCount                  KEYWORD2
 pullup                         KEYWORD2
 pulldown                       KEYWORD2
 held                           KEYWORD2
 heldFor                        KEYWORD2
+setMultiClickThreshold         KEYWORD2
 setHoldThreshold               KEYWORD2
 pressHandler                   KEYWORD2
 releaseHandler                 KEYWORD2


### PR DESCRIPTION
The multiClickHandler may break projects using the clickHandler since the multiClickHandler is triggered instead of the clickHandler.
Use getClickCount() within the clickHandler trigger to find out how
often the key (multi click) was clicked.

350ms is used as default value for multiClickEventThreshold
updated the example
updated keywords.txt
