### PR TITLE
add dummy -clean deps inside linux and windows plat-build to fix building

### DIFF
--- a/build/linux/plat-build.xml
+++ b/build/linux/plat-build.xml
@@ -73,11 +73,15 @@
     <exec executable="${dist.wiring.script}"/>
   </target>
 
+  <target name="-clean">
+  </target>
+
   <!-- Dependency resolution -->
 
   <target name="-resolve.deps"
           depends="platform.-resolve.dep.avr">
   </target>
+
 
   <!-- Override AVR toolchain using a real tar, so symlinks work. -->
   <target name="-resolve.dep.avr"

--- a/build/windows/plat-build.xml
+++ b/build/windows/plat-build.xml
@@ -101,6 +101,9 @@
     <exec executable="${dist.wiring.exe}" spawn="true"/>
   </target>
 
+  <target name="-clean">
+  </target>
+
   <!-- Dependency resolution -->
 
   <target name="-resolve.deps"


### PR DESCRIPTION
-clean exists in macosx but not in windows and linux making ant to fail on these platforms

Signed-off-by: Arnav Gupta championswimmer@gmail.com
