### PR TITLE
Slight change in equality check in MenuBackend.h

### DIFF
--- a/framework/libraries/MenuBackend/MenuBackend.h
+++ b/framework/libraries/MenuBackend/MenuBackend.h
@@ -462,7 +462,7 @@ class MenuItem
     bool isEqual(MenuItem &mi)
     {
       //TODO extend equality test
-      return (menuTestStrings(getName(), mi.getName()) && getValue() == mi.getValue());
+      return (menuTestStrings(getName(), mi.getName()) && getValue() == mi.getValue() && getBack() == mi.getBack());
     }
 
   protected:


### PR DESCRIPTION
Check that the historical back is the same to avoid false detection of an item with the same name in different sub menus (e.g. ON/OFF, Enable/Disable).