### PR TITLE
updated stale URLs in build files

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -91,7 +91,7 @@
             location="${deps.archive}/tools-avr.tgz"/>
 
   <property name="dep.reference.remote"
-            value="http://wiring.googlecode.com/files/reference.zip"/>
+            value="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/wiring/reference.zip"/>
   <property name="dep.reference.local"
             location="${deps.archive}/reference.zip"/>
 

--- a/build/linux/plat-build.xml
+++ b/build/linux/plat-build.xml
@@ -27,7 +27,7 @@
 
   <!-- Dependencies -->
   <property name="dep.toolchain.avr.remote"
-            value="http://wiring.googlecode.com/files/tools-avr-linux-i586.tar.gz"/>
+            value="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/wiring/tools-avr-linux-i586.tar.gz"/>
 
   <!-- =======
        Targets

--- a/build/macosx/plat-build.xml
+++ b/build/macosx/plat-build.xml
@@ -46,11 +46,11 @@
 
   <!-- Dependencies -->
   <property name="dep.toolchain.avr.remote"
-            value="http://wiring.googlecode.com/files/tools-avr-1.0-macosx-10.6.tar.gz"/>
+            value="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/wiring/tools-avr-1.0-macosx-10.6.tar.gz"/>
   <property name="dep.avr.default.ok" value="true"/>
 
   <property name="dep.toolchain.common.remote"
-            value="http://wiring.googlecode.com/files/tools-common-1.0-macosx-10.6.tar.gz"/>
+            value="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/wiring/tools-common-1.0-macosx-10.6.tar.gz"/>
   <property name="dep.common.default.ok" value="true"/>
   
   <!-- =======

--- a/build/windows/plat-build.xml
+++ b/build/windows/plat-build.xml
@@ -30,21 +30,21 @@
   <!-- Dependencies -->
 
   <property name="dep.toolchain.avr.remote"
-            value="http://wiring.googlecode.com/files/tools-avr-1.0-windows-i586.tar.gz"/>
+            value="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/wiring/tools-avr-1.0-windows-i586.tar.gz"/>
   <property name="dep.avr.default.ok" value="true"/>
   
   <property name="dep.toolchain.common.remote"
-            value="http://wiring.googlecode.com/files/tools-common-1.0-windows-i586.tar.gz"/>
+            value="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/wiring/tools-common-1.0-windows-i586.tar.gz"/>
   <property name="dep.common.default.ok" value="true"/>
 
   <property name="dep.jre.remote"
-            value="http://wiring.googlecode.com/files/jre-tools-6u37-windows32.zip"/>
+            value="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/wiring/jre-tools-6u37-windows32.zip"/>
   <property name="dep.jre.local"
             location="${deps.archive}/jre.tgz"/>
 
   <!--
   <property name="dep.cygwindlls.remote"
-            value="http://wiring.googlecode.com/files/cygwin-dlls-1.0.zip"/>
+            value="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/wiring/cygwin-dlls-1.0.zip"/>
   <property name="dep.cygwindlls.local"
             location="${deps.archive}/cygwin-dlls.zip"/>
   -->


### PR DESCRIPTION
Resolved Build.xml remote file issues #47
- GoogleCode is no longer a product, file URLs have been relocated, see: https://github.com/WiringProject/Wiring/issues/47

"Step 1: Open an editor (like Atom) and search the entire project for this string
**http://wiring.googlecode.com/files/**

and do a replace all with this string:
**https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/wiring/**

Step 2: run "ant" again"

